### PR TITLE
Fix replaceLocation to be more robust.

### DIFF
--- a/annotation_test.go
+++ b/annotation_test.go
@@ -208,7 +208,7 @@ func (*annotationSuite) TestErrorStack(c *gc.C) {
 		c.Logf("%v: %s", i, test.message)
 		err := test.generator()
 		expected := replaceLocations(test.expected)
-		ok := c.Check(errors.ErrorStack(err), gc.Equals, expected)
+		ok := c.Check(errors.ErrorStack(err), gc.Matches, expected)
 		if !ok {
 			c.Logf("%#v", err)
 		}
@@ -273,7 +273,7 @@ func location(tag string) errgo.Location {
 		panic(fmt.Errorf("tag %q not found", tag))
 	}
 	return errgo.Location{
-		File: "github.com/juju/errors/annotation_test.go",
+		File: ".*github.com/juju/errors/annotation_test.go",
 		Line: line,
 	}
 }


### PR DESCRIPTION
For some reason running the tests under the cover tool was causing the _entire_ source path, not just the bit from `$GOPATH/src` to appear.

As there really isn't any guarantee what will be returned from runtime.Callers (you should see gccgo), make the test a bit more liberal in what we accept.
