### PR TITLE
Fixed outdated import

### DIFF
--- a/annotation_test.go
+++ b/annotation_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/errgo"
 	"github.com/juju/errors"

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 // errorInfo holds information about a single error type: a satisfier

--- a/package_test.go
+++ b/package_test.go
@@ -6,7 +6,7 @@ package errors_test
 import (
 	"testing"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) {

--- a/path_test.go
+++ b/path_test.go
@@ -6,7 +6,7 @@ package errors_test
 import (
 	"path"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/errors"
 )


### PR DESCRIPTION
This PR changes the import of gocheck from launchpad to github.
