### PR TITLE
use gopkg.in/errgo.v1

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 )
 
 // NOTE: the SetLocation calls explicitly call into the embedded errgo Err
@@ -167,12 +167,11 @@ func ErrorStack(err error) string {
 	for {
 		var buff []byte
 		if err, ok := err.(errgo.Locationer); ok {
-			loc := err.Location()
+			file, line := err.Location()
 			// Strip off the leading GOPATH/src path elements.
-			loc.File = trimGoPath(loc.File)
-			if loc.IsSet() {
-				buff = append(buff, loc.String()...)
-				buff = append(buff, ": "...)
+			if file != "" {
+				file = trimGoPath(file)
+				buff = append(buff, fmt.Sprintf("%s:%d: ", file, line)...)
 			}
 		}
 		if cerr, ok := err.(errgo.Wrapper); ok {

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -12,8 +12,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errgo"
 	"github.com/juju/errors"
+	"gopkg.in/errgo.v1"
 )
 
 type annotationSuite struct{}
@@ -261,22 +261,19 @@ func replaceLocations(s string) string {
 		if i == -1 {
 			panic("no second $")
 		}
-		t += location(s[0:i]).String()
+		t += location(s[0:i])
 		s = s[i+1:]
 	}
 	t += s
 	return t
 }
 
-func location(tag string) errgo.Location {
+func location(tag string) string {
 	line, ok := tagToLine[tag]
 	if !ok {
 		panic(fmt.Errorf("tag %q not found", tag))
 	}
-	return errgo.Location{
-		File: "github.com/juju/errors/annotation_test.go",
-		Line: line,
-	}
+	return fmt.Sprintf("github.com/juju/errors/annotation_test.go:%d", line)
 }
 
 var tagToLine = make(map[string]int)

--- a/errors.go
+++ b/errors.go
@@ -6,8 +6,8 @@ package errors
 import (
 	"fmt"
 
-	"github.com/juju/errgo"
 	"github.com/juju/loggo"
+	"gopkg.in/errgo.v1"
 )
 
 // NOTE: the SetLocation calls explicitly call into the embedded errgo Err


### PR DESCRIPTION
This is now the standard package path for the errgo package.

It is almost exactly the same as the existing github.com/juju/errgo package
except that it defines the Location method slightly differently so that
error stacks will work correctly even if multiple versions of the
errgo package are imported.
