### PR TITLE
Remove the dependency on loggo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,13 +248,6 @@ IsUnauthorized reports whether err was created with Unauthorizedf() or
 NewUnauthorized().
 
 
-## func LoggedErrorf
-``` go
-func LoggedErrorf(logger loggo.Logger, format string, a ...interface{}) error
-```
-LoggedErrorf logs the error and return an error with the same text.
-
-
 ## func Mask
 ``` go
 func Mask(other error) error

--- a/errortypes.go
+++ b/errortypes.go
@@ -5,8 +5,6 @@ package errors
 
 import (
 	"fmt"
-
-	"github.com/juju/loggo"
 )
 
 // wrap is a helper to construct an *wrapper.
@@ -161,10 +159,4 @@ func IsNotValid(err error) bool {
 	err = Cause(err)
 	_, ok := err.(*notValid)
 	return ok
-}
-
-// LoggedErrorf logs the error and return an error with the same text.
-func LoggedErrorf(logger loggo.Logger, format string, a ...interface{}) error {
-	logger.Logf(loggo.ERROR, format, a...)
-	return fmt.Errorf(format, a...)
 }


### PR DESCRIPTION
It seems stupid to pull in loggo for something so trivial.

If we decide to have this method, which I'm not sure we should, we should put it in loggo.
