### PR TITLE
errors: move NotProvisioned from juju/juju/state

### DIFF
--- a/errortypes.go
+++ b/errortypes.go
@@ -184,3 +184,27 @@ func IsNotValid(err error) bool {
 	_, ok := err.(*notValid)
 	return ok
 }
+
+// notProvisioned represents an error when something is not yet provisioned.
+type notProvisioned struct {
+	Err
+}
+
+// NotProvisionedf returns an error which satisfies IsNotProvisioned().
+func NotProvisionedf(format string, args ...interface{}) error {
+	return &notProvisioned{wrap(nil, format, " not provisioned", args...)}
+}
+
+// NewNotProvisioned returns an error which wraps err that satisfies
+// IsNotProvisioned().
+func NewNotProvisioned(err error, msg string) error {
+	return &notProvisioned{wrap(err, msg, "")}
+}
+
+// IsNotProvisioned reports whether err was created with NotProvisionedf() or
+// NewNotProvisioned().
+func IsNotProvisioned(err error) bool {
+	err = Cause(err)
+	_, ok := err.(*notProvisioned)
+	return ok
+}

--- a/errortypes_test.go
+++ b/errortypes_test.go
@@ -34,6 +34,7 @@ var allErrors = []*errorInfo{
 	&errorInfo{errors.IsAlreadyExists, errors.AlreadyExistsf, errors.NewAlreadyExists, " already exists"},
 	&errorInfo{errors.IsNotSupported, errors.NotSupportedf, errors.NewNotSupported, " not supported"},
 	&errorInfo{errors.IsNotValid, errors.NotValidf, errors.NewNotValid, " not valid"},
+	&errorInfo{errors.IsNotProvisioned, errors.NotProvisionedf, errors.NewNotProvisioned, " not provisioned"},
 }
 
 type errorTypeSuite struct{}


### PR DESCRIPTION
The NotProvisioned error type and function will
be reused for disk provisioning. Let's move the
error type out of state while we're at it, to
avoid unnecessary dependencies.