### PR TITLE
Add NewErrWithCause method to construct err with cause.

### DIFF
--- a/error.go
+++ b/error.go
@@ -52,6 +52,29 @@ func NewErr(format string, args ...interface{}) Err {
 	}
 }
 
+// NewErrWithCause is used to return an Err with case by other error for the purpose of embedding in other
+// structures. The location is not specified, and needs to be set with a call
+// to SetLocation.
+//
+// For example:
+//     type FooError struct {
+//         errors.Err
+//         code int
+//     }
+//
+//     func (e *FooError) Annotate(format string, args ...interface{}) error {
+//         err := &FooError{errors.NewErrWithCause(e.Err, format, args...), e.code}
+//         err.SetLocation(1)
+//         return err
+//     })
+func NewErrWithCause(other error, format string, args ...interface{}) Err {
+	return Err{
+		message:  fmt.Sprintf(format, args...),
+		cause:    Cause(other),
+		previous: other,
+	}
+}
+
 // Location is the file and line of where the error was most recently
 // created or annotated.
 func (e *Err) Location() (filename string, line int) {

--- a/error_test.go
+++ b/error_test.go
@@ -128,6 +128,23 @@ func (*errorsSuite) TestNewErr(c *gc.C) {
 	c.Assert(errors.Details(err), jc.Contains, tagToLocation["embedErr"].String())
 }
 
+func newEmbedWithCause(other error, format string, args ...interface{}) *embed {
+	err := &embed{errors.NewErrWithCause(other, format, args...)}
+	err.SetLocation(1)
+	return err
+}
+
+func (*errorsSuite) TestNewErrWithCause(c *gc.C) {
+	if runtime.Compiler == "gccgo" {
+		c.Skip("gccgo can't determine the location")
+	}
+	causeErr := fmt.Errorf("external error")
+	err := newEmbedWithCause(causeErr, "testing %d", 43) //err embedCause
+	c.Assert(err.Error(), gc.Equals, "testing 43: external error")
+	c.Assert(errors.Cause(err), gc.Equals, causeErr)
+	c.Assert(errors.Details(err), jc.Contains, tagToLocation["embedCause"].String())
+}
+
 var _ error = (*embed)(nil)
 
 // This is an uncomparable error type, as it is a struct that supports the

--- a/functions_test.go
+++ b/functions_test.go
@@ -73,8 +73,8 @@ func (*functionSuite) TestDeferredAnnotatef(c *gc.C) {
 	first := errors.New("first")
 	test := func() (err error) {
 		defer errors.DeferredAnnotatef(&err, "deferred %s", "annotate")
-		return first
-	} //err deferredAnnotate
+		return first //err deferredAnnotate
+	}
 	err := test()
 	c.Assert(err.Error(), gc.Equals, "deferred annotate: first")
 	c.Assert(errors.Cause(err), gc.Equals, first)

--- a/functions_test.go
+++ b/functions_test.go
@@ -73,8 +73,8 @@ func (*functionSuite) TestDeferredAnnotatef(c *gc.C) {
 	first := errors.New("first")
 	test := func() (err error) {
 		defer errors.DeferredAnnotatef(&err, "deferred %s", "annotate")
-		return first //err deferredAnnotate
-	}
+		return first
+	} //err deferredAnnotate
 	err := test()
 	c.Assert(err.Error(), gc.Equals, "deferred annotate: first")
 	c.Assert(errors.Cause(err), gc.Equals, first)


### PR DESCRIPTION
Add NewErrWithCause method to construct err with cause.

just like `NewErr`...user also need a way to build custom error and do something like `Trace` or `Annotate`

but,there is no way to create Err with cause error but without setLocation called.. 

so It's better to add this~ thx

(Review request: http://reviews.vapour.ws/r/3350/)