### PR TITLE
fix panic on 1.4.x with chained imports

### DIFF
--- a/path.go
+++ b/path.go
@@ -17,6 +17,9 @@ var goPath string
 
 func init() {
 	_, file, _, ok := runtime.Caller(0)
+	if file == "?" {
+		return
+	}
 	if ok {
 		// We know that the end of the file should be:
 		// github.com/juju/errors/path.go


### PR DESCRIPTION
I actually do not know the root cause of this error, but I've managed to reproduce it by chaining lots of imports together.  At some point (only on go 1.4), having a deep import tree can lead to `runtime.Caller` returning a strange error condition during `init()` where `ok` is true but `file` is improperly left at an initialization value.  This checks for that value and bails if it's found.

For more information on this error, and to reproduce it yourself, look at https://github.com/jmoiron/jujut