### PR TITLE
Print the stack trace when formatting with %+v

### DIFF
--- a/error.go
+++ b/error.go
@@ -132,10 +132,13 @@ func (e *Err) Format(s fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case s.Flag('+'):
-			fmt.Fprintf(s, "%s\n%s", e.Error(), ErrorStack(e))
+			fmt.Fprintf(s, "%s", ErrorStack(e))
 			return
 		case s.Flag('#'):
+			// avoid infinite recursion by wrapping e into a type
+			// that doesn't implement Formatter.
 			fmt.Fprintf(s, "%#v", (*unformatter)(e))
+			return
 		}
 		fallthrough
 	case 's':

--- a/error.go
+++ b/error.go
@@ -124,6 +124,30 @@ func (e *Err) Error() string {
 	return fmt.Sprintf("%s: %v", e.message, err)
 }
 
+// Format implements fmt.Formatter
+// When printing errors with %+v it also prints the stack trace.
+// %#v unsurprisingly will print the real underlying type.
+func (e *Err) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			fmt.Fprintf(s, "%s\n%s", e.Error(), ErrorStack(e))
+			return
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", (*unformatter)(e))
+		}
+		fallthrough
+	case 's':
+		fmt.Fprintf(s, "%s", e.Error())
+	}
+}
+
+// helper for Format
+type unformatter Err
+
+func (unformatter) Format() { /* break the fmt.Formatter interface */ }
+
 // SetLocation records the source location of the error at callDepth stack
 // frames above the call.
 func (e *Err) SetLocation(callDepth int) {


### PR DESCRIPTION
Discovered in:
http://dave.cheney.net/2016/06/12/stack-traces-and-the-errors-package

Code based on:
https://github.com/pkg/errors

With a minor but hackish change to still allow %#v to print the structure fields, in order to not break the principle of least surprise. Let me know if there is a better way to strip a type of an interface or invoke the default %#v behaviour on a type that implements fmt.Formatter.

---

NOTE: this is the continuation of #26. I no longer work for cesanta and thus cannot address comments in the original PR.

#26 received the green light from @mjs, and had an open question by @howbazaar, whom I replied to.