### PR TITLE
Add forbidden error

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,13 @@ func Unauthorizedf(format string, args ...interface{}) error
 Unauthorizedf returns an error which satisfies IsUnauthorized().
 
 
+## func Forbiddenf
+``` go
+func Forbiddenf(format string, args ...interface{}) error
+```
+Forbiddenf returns an error which satisfies IsForbidden().
+
+
 ## func Wrap
 ``` go
 func Wrap(other, newDescriptive error) error

--- a/errortypes.go
+++ b/errortypes.go
@@ -282,3 +282,28 @@ func IsMethodNotAllowed(err error) bool {
 	_, ok := err.(*methodNotAllowed)
 	return ok
 }
+
+// forbidden represents an error when a request cannot be completed because of
+// missing privileges
+type forbidden struct {
+	Err
+}
+
+// Forbiddenf returns an error which satistifes IsForbidden()
+func Forbiddenf(format string, args ...interface{}) error {
+	return &forbidden{wrap(nil, format, "", args...)}
+}
+
+// NewForbidden returns an error which wraps err that satisfies
+// IsForbidden().
+func NewForbidden(err error, msg string) error {
+	return &forbidden{wrap(err, msg, "")}
+}
+
+// IsForbidden reports whether err was created with Forbiddenf() or
+// NewForbidden().
+func IsForbidden(err error) bool {
+	err = Cause(err)
+	_, ok := err.(*forbidden)
+	return ok
+}

--- a/errortypes_test.go
+++ b/errortypes_test.go
@@ -38,6 +38,7 @@ var allErrors = []*errorInfo{
 	&errorInfo{errors.IsNotAssigned, errors.NotAssignedf, errors.NewNotAssigned, " not assigned"},
 	&errorInfo{errors.IsMethodNotAllowed, errors.MethodNotAllowedf, errors.NewMethodNotAllowed, ""},
 	&errorInfo{errors.IsBadRequest, errors.BadRequestf, errors.NewBadRequest, ""},
+	&errorInfo{errors.IsForbidden, errors.Forbiddenf, errors.NewForbidden, ""},
 }
 
 type errorTypeSuite struct{}


### PR DESCRIPTION
The "forbidden" error is missing, and since most of the common http errors are implemented, I believe it'd be nice to add this one.