### PR TITLE
made getgopath more accurate

### DIFF
--- a/path.go
+++ b/path.go
@@ -4,7 +4,10 @@
 package errors
 
 import (
-	"runtime"
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,25 +17,21 @@ var prefixSize int
 
 // goPath is the deduced path based on the location of this file as compiled.
 var goPath string
+var srcDir string
 
 func init() {
-	_, file, _, ok := runtime.Caller(0)
-	if file == "?" {
-		return
+	goPath = getGOPATH()
+	srcDir = filepath.Join(goPath, "src")
+}
+
+func getGOPATH() string {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = build.Default.GOPATH
 	}
-	if ok {
-		// We know that the end of the file should be:
-		// github.com/juju/errors/path.go
-		size := len(file)
-		suffix := len("github.com/juju/errors/path.go")
-		goPath = file[:size-suffix]
-		prefixSize = len(goPath)
-	}
+	return gopath
 }
 
 func trimGoPath(filename string) string {
-	if strings.HasPrefix(filename, goPath) {
-		return filename[prefixSize:]
-	}
-	return filename
+	return strings.Replace(filename, fmt.Sprintf("%s/", srcDir), "", 1)
 }

--- a/path.go
+++ b/path.go
@@ -11,27 +11,9 @@ import (
 	"strings"
 )
 
-// prefixSize is used internally to trim the user specific path from the
-// front of the returned filenames from the runtime call stack.
-var prefixSize int
-
-// goPath is the deduced path based on the location of this file as compiled.
-var goPath string
-var srcDir string
-
-func init() {
-	goPath = getGOPATH()
-	srcDir = filepath.Join(goPath, "src")
-}
-
-func getGOPATH() string {
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		gopath = build.Default.GOPATH
-	}
-	return gopath
-}
+var goPath = build.Default.GOPATH
+var srcDir = filepath.Join(goPath, "src")
 
 func trimGoPath(filename string) string {
-	return strings.Replace(filename, fmt.Sprintf("%s/", srcDir), "", 1)
+	return strings.TrimPrefix(filename, fmt.Sprintf("%s%s", srcDir, string(os.PathSeparator)))
 }

--- a/path_test.go
+++ b/path_test.go
@@ -4,7 +4,7 @@
 package errors_test
 
 import (
-	"path"
+	"path/filepath"
 
 	gc "gopkg.in/check.v1"
 
@@ -21,7 +21,7 @@ func (*pathSuite) TestGoPathSet(c *gc.C) {
 
 func (*pathSuite) TestTrimGoPath(c *gc.C) {
 	relativeImport := "github.com/foo/bar/baz.go"
-	filename := path.Join(errors.GoPath(), "src", relativeImport)
+	filename := filepath.Join(errors.GoPath(), "src", relativeImport)
 	c.Assert(errors.TrimGoPath(filename), gc.Equals, relativeImport)
 
 	absoluteImport := "/usr/share/foo/bar/baz.go"

--- a/path_test.go
+++ b/path_test.go
@@ -21,7 +21,7 @@ func (*pathSuite) TestGoPathSet(c *gc.C) {
 
 func (*pathSuite) TestTrimGoPath(c *gc.C) {
 	relativeImport := "github.com/foo/bar/baz.go"
-	filename := path.Join(errors.GoPath(), relativeImport)
+	filename := path.Join(errors.GoPath(), "src", relativeImport)
 	c.Assert(errors.TrimGoPath(filename), gc.Equals, relativeImport)
 
 	absoluteImport := "/usr/share/foo/bar/baz.go"


### PR DESCRIPTION
the previous way to get `$GOPATH` breaks now because we have dependencies put at `./vendor` rather `$GOPATH/src/. So now get `$GOPATH` from `go/build.Default.GOPATH`