### PR TITLE
[JUJU-753] Add `Err.Unwrap` to support standard error library (Go 1.13+)

### DIFF
--- a/error.go
+++ b/error.go
@@ -90,6 +90,12 @@ func (e *Err) Underlying() error {
 	return e.previous
 }
 
+// Unwrap is a synonym for Underlying, provided only to match the functionality
+// of Go's standard `errors` library.
+func (e *Err) Unwrap() error {
+	return e.previous
+}
+
 // Cause returns the most recent error in the error stack that
 // meets one of these criteria: the original error that was raised; the new
 // error that was passed into the Wrap function; the most recently masked

--- a/error.go
+++ b/error.go
@@ -90,12 +90,6 @@ func (e *Err) Underlying() error {
 	return e.previous
 }
 
-// Unwrap is a synonym for Underlying, which allows Err to be used with the
-// Unwrap, Is and As functions in Go's standard `errors` library.
-func (e *Err) Unwrap() error {
-	return e.previous
-}
-
 // Cause returns the most recent error in the error stack that
 // meets one of these criteria: the original error that was raised; the new
 // error that was passed into the Wrap function; the most recently masked
@@ -179,4 +173,10 @@ func (e *Err) StackTrace() []string {
 // Ideally we'd have a way to check identity, but deep equals will do.
 func sameError(e1, e2 error) bool {
 	return reflect.DeepEqual(e1, e2)
+}
+
+// Unwrap is a synonym for Underlying, which allows Err to be used with the
+// Unwrap, Is and As functions in Go's standard `errors` library.
+func (e *Err) Unwrap() error {
+	return e.previous
 }

--- a/error.go
+++ b/error.go
@@ -90,8 +90,8 @@ func (e *Err) Underlying() error {
 	return e.previous
 }
 
-// Unwrap is a synonym for Underlying, provided only to match the functionality
-// of Go's standard `errors` library.
+// Unwrap is a synonym for Underlying, which allows Err to be used with the
+// Unwrap, Is and As functions in Go's standard `errors` library.
 func (e *Err) Unwrap() error {
 	return e.previous
 }

--- a/error_test.go
+++ b/error_test.go
@@ -96,6 +96,38 @@ func (*errorsSuite) TestErrorString(c *gc.C) {
 				return errors.Trace(err)
 			},
 			expected: "more context: masked: some context: first error",
+		}, {
+			message: "error traced then unwrapped",
+			generator: func() error {
+				err := errors.New("inner error")
+				err = errors.Trace(err)
+				return errors.Unwrap(err)
+			},
+			expected: "inner error",
+		}, {
+			message: "error annotated then unwrapped",
+			generator: func() error {
+				err := errors.New("inner error")
+				err = errors.Annotate(err, "annotation")
+				return errors.Unwrap(err)
+			},
+			expected: "inner error",
+		}, {
+			message: "error wrapped then unwrapped",
+			generator: func() error {
+				err := errors.New("inner error")
+				err = errors.Wrap(err, errors.New("cause"))
+				return errors.Unwrap(err)
+			},
+			expected: "inner error",
+		}, {
+			message: "error masked then unwrapped",
+			generator: func() error {
+				err := errors.New("inner error")
+				err = errors.Mask(err)
+				return errors.Unwrap(err)
+			},
+			expected: "inner error",
 		},
 	} {
 		c.Logf("%v: %s", i, test.message)
@@ -142,6 +174,11 @@ func (*errorsSuite) TestNewErrWithCause(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "testing 43: external error")
 	c.Assert(errors.Cause(err), gc.Equals, causeErr)
 	c.Assert(errors.Details(err), Contains, tagToLocation["embedCause"].String())
+}
+
+func (*errorsSuite) TestUnwrapNewErrGivesNil(c *gc.C) {
+	err := errors.New("test error")
+	c.Assert(errors.Unwrap(err), gc.Equals, nil)
 }
 
 var _ error = (*embed)(nil)

--- a/error_test.go
+++ b/error_test.go
@@ -178,7 +178,7 @@ func (*errorsSuite) TestNewErrWithCause(c *gc.C) {
 
 func (*errorsSuite) TestUnwrapNewErrGivesNil(c *gc.C) {
 	err := errors.New("test error")
-	c.Assert(errors.Unwrap(err), gc.Equals, nil)
+	c.Assert(errors.Unwrap(err), gc.IsNil)
 }
 
 var _ error = (*embed)(nil)

--- a/functions.go
+++ b/functions.go
@@ -4,7 +4,7 @@
 package errors
 
 import (
-	goerrors "errors"
+	stderrors "errors"
 	"fmt"
 	"strings"
 )
@@ -330,6 +330,16 @@ func errorStack(err error) []string {
 	return result
 }
 
-// Unwrap is an alias for the Unwrap function in Go's standard `errors` library
-// (pkg.go.dev/errors).
-var Unwrap = goerrors.Unwrap
+// Unwrap, Is and As are proxies for the corresponding functions in Go's
+// standard `errors` library (pkg.go.dev/errors).
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}
+
+func Is(err, target error) bool {
+	return stderrors.Is(err, target)
+}
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}

--- a/functions.go
+++ b/functions.go
@@ -4,6 +4,7 @@
 package errors
 
 import (
+	goerrors "errors"
 	"fmt"
 	"strings"
 )
@@ -329,22 +330,6 @@ func errorStack(err error) []string {
 	return result
 }
 
-// Unwrap returns the previous error in the stack. It calls the Unwrap method
-// on its argument if possible, and otherwise returns nil.
-//
-// This method is provided to match the functionality of Go's `errors` library
-// (pkg.go.dev/errors). In most cases, the error's *cause* will be more
-// relevant, so you should use the `Cause` method instead.
-func Unwrap(err error) error {
-	u, hasUnwrap := err.(unwrappable)
-
-	if hasUnwrap {
-		return u.Unwrap()
-	} else {
-		return nil
-	}
-}
-
-type unwrappable interface {
-	Unwrap() error
-}
+// Unwrap is an alias for the Unwrap function in Go's standard `errors` library
+// (pkg.go.dev/errors).
+var Unwrap = goerrors.Unwrap

--- a/functions.go
+++ b/functions.go
@@ -328,3 +328,23 @@ func errorStack(err error) []string {
 	}
 	return result
 }
+
+// Unwrap returns the previous error in the stack. It calls the Unwrap method
+// on its argument if possible, and otherwise returns nil.
+//
+// This method is provided to match the functionality of Go's `errors` library
+// (pkg.go.dev/errors). In most cases, the error's *cause* will be more
+// relevant, so you should use the `Cause` method instead.
+func Unwrap(err error) error {
+	u, hasUnwrap := err.(unwrappable)
+
+	if hasUnwrap {
+		return u.Unwrap()
+	} else {
+		return nil
+	}
+}
+
+type unwrappable interface {
+	Unwrap() error
+}

--- a/functions.go
+++ b/functions.go
@@ -330,16 +330,20 @@ func errorStack(err error) []string {
 	return result
 }
 
-// Unwrap, Is and As are proxies for the corresponding functions in Go's
-// standard `errors` library (pkg.go.dev/errors).
+// Unwrap is a proxy for the Unwrap function in Go's standard `errors` library
+// (pkg.go.dev/errors).
 func Unwrap(err error) error {
 	return stderrors.Unwrap(err)
 }
 
+// Is is a proxy for the Is function in Go's standard `errors` library
+// (pkg.go.dev/errors).
 func Is(err, target error) bool {
 	return stderrors.Is(err, target)
 }
 
+// As is a proxy for the As function in Go's standard `errors` library
+// (pkg.go.dev/errors).
 func As(err error, target interface{}) bool {
 	return stderrors.As(err, target)
 }

--- a/functions_test.go
+++ b/functions_test.go
@@ -331,3 +331,43 @@ func (*functionSuite) TestFormat(c *gc.C) {
 		c.Check(s, gc.Equals, expect)
 	}
 }
+
+type basicError struct {
+	Reason string
+}
+
+func (b *basicError) Error() string {
+	return b.Reason
+}
+
+func (*functionSuite) TestAs(c *gc.C) {
+	baseError := &basicError{"I'm an error"}
+	testErrors := []error{
+		errors.Trace(baseError),
+		errors.Annotate(baseError, "annotation"),
+		errors.Wrap(baseError, errors.New("wrapper")),
+		errors.Mask(baseError),
+	}
+
+	for _, err := range testErrors {
+		bError := &basicError{}
+		val := errors.As(err, &bError)
+		c.Check(val, gc.Equals, true)
+		c.Check(bError.Reason, gc.Equals, "I'm an error")
+	}
+}
+
+func (*functionSuite) TestIs(c *gc.C) {
+	baseError := &basicError{"I'm an error"}
+	testErrors := []error{
+		errors.Trace(baseError),
+		errors.Annotate(baseError, "annotation"),
+		errors.Wrap(baseError, errors.New("wrapper")),
+		errors.Mask(baseError),
+	}
+
+	for _, err := range testErrors {
+		val := errors.Is(err, baseError)
+		c.Check(val, gc.Equals, true)
+	}
+}


### PR DESCRIPTION
Since v1.13, Go's [`errors`](https://pkg.go.dev/errors) library has supported wrapping errors inside other errors, and manipulating these with the `Is`, `As`, and `Unwrap` functions. Here, I've added an `Unwrap` method to `Err` so that these functions are compatible with `Err`.

I also added proxies for the `Is`, `As`, and `Unwrap` functions, closes #47. Finally, I've written unit tests for the `Unwrap` method in `error_test.go`.

