### PR TITLE
[JUJU-759] Change error types to use new ConstError

### DIFF
--- a/errortypes.go
+++ b/errortypes.go
@@ -7,6 +7,78 @@ import (
 	"fmt"
 )
 
+// a ConstError is a prototype for a certain type of error
+type ConstError string
+
+// ConstError implements error
+func (e ConstError) Error() string {
+	return ""
+}
+
+// Different types of errors
+const (
+	// Timeout represents an error on timeout.
+	Timeout = ConstError("timeout")
+	// NotFound represents an error when something has not been found.
+	NotFound = ConstError("not found")
+	// UserNotFound represents an error when a non-existent user is looked up.
+	UserNotFound = ConstError("user not found")
+	// Unauthorized represents an error when an operation is unauthorized.
+	Unauthorized = ConstError("unauthorized")
+	// NotImplemented represents an error when something is not
+	// implemented.
+	NotImplemented = ConstError("not implemented")
+	// AlreadyExists represents and error when something already exists.
+	AlreadyExists = ConstError("already exists")
+	// NotSupported represents an error when something is not supported.
+	NotSupported = ConstError("not supported")
+	// NotValid represents an error when something is not valid.
+	NotValid = ConstError("not valid")
+	// NotProvisioned represents an error when something is not yet provisioned.
+	NotProvisioned = ConstError("not provisioned")
+	// NotAssigned represents an error when something is not yet assigned to
+	// something else.
+	NotAssigned = ConstError("not assigned")
+	// BadRequest represents an error when a request has bad parameters.
+	BadRequest = ConstError("bad request")
+	// MethodNotAllowed represents an error when an HTTP request
+	// is made with an inappropriate method.
+	MethodNotAllowed = ConstError("method not allowed")
+	// Forbidden represents an error when a request cannot be completed because of
+	// missing privileges.
+	Forbidden = ConstError("forbidden")
+	// QuotaLimitExceeded is emitted when an action failed due to a quota limit check.
+	QuotaLimitExceeded = ConstError("quota limit exceeded")
+	// NotYetAvailable is the error returned when a resource is not yet available
+	// but it might be in the future.
+	NotYetAvailable = ConstError("not yet available")
+)
+
+// errWithType is an Err bundled with its error type (a ConstError)
+type errWithType struct {
+	err     Err
+	errType ConstError
+}
+
+// errWithType implements error
+func (e *errWithType) Error() string {
+	return e.err.Error()
+}
+
+// e.Is compares `target` with e's error type
+func (e *errWithType) Is(target error) bool {
+	if &e.errType == nil {
+		return false
+	} else {
+		return target == e.errType
+	}
+}
+
+// Unwrapping an errWithType gives the underlying Err
+func (e *errWithType) Unwrap() error {
+	return &e.err
+}
+
 // wrap is a helper to construct an *wrapper.
 func wrap(err error, format, suffix string, args ...interface{}) Err {
 	newErr := Err{
@@ -17,366 +89,346 @@ func wrap(err error, format, suffix string, args ...interface{}) Err {
 	return newErr
 }
 
-// timeout represents an error on timeout.
-type timeout struct {
-	Err
-}
-
 // Timeoutf returns an error which satisfies IsTimeout().
 func Timeoutf(format string, args ...interface{}) error {
-	return &timeout{wrap(nil, format, " timeout", args...)}
+	return &errWithType{
+		wrap(nil, format, " timeout", args...),
+		Timeout,
+	}
 }
 
 // NewTimeout returns an error which wraps err that satisfies
 // IsTimeout().
 func NewTimeout(err error, msg string) error {
-	return &timeout{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		Timeout,
+	}
 }
 
 // IsTimeout reports whether err was created with Timeoutf() or
 // NewTimeout().
 func IsTimeout(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*timeout)
-	return ok
-}
-
-// notFound represents an error when something has not been found.
-type notFound struct {
-	Err
+	return Is(err, Timeout)
 }
 
 // NotFoundf returns an error which satisfies IsNotFound().
 func NotFoundf(format string, args ...interface{}) error {
-	return &notFound{wrap(nil, format, " not found", args...)}
+	return &errWithType{
+		wrap(nil, format, " not found", args...),
+		NotFound,
+	}
 }
 
 // NewNotFound returns an error which wraps err that satisfies
 // IsNotFound().
 func NewNotFound(err error, msg string) error {
-	return &notFound{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotFound,
+	}
 }
 
 // IsNotFound reports whether err was created with NotFoundf() or
 // NewNotFound().
 func IsNotFound(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notFound)
-	return ok
-}
-
-// userNotFound represents an error when an inexistent user is looked up.
-type userNotFound struct {
-	Err
+	return Is(err, NotFound)
 }
 
 // UserNotFoundf returns an error which satisfies IsUserNotFound().
 func UserNotFoundf(format string, args ...interface{}) error {
-	return &userNotFound{wrap(nil, format, " user not found", args...)}
+	return &errWithType{
+		wrap(nil, format, " user not found", args...),
+		UserNotFound,
+	}
 }
 
 // NewUserNotFound returns an error which wraps err and satisfies
 // IsUserNotFound().
 func NewUserNotFound(err error, msg string) error {
-	return &userNotFound{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		UserNotFound,
+	}
 }
 
 // IsUserNotFound reports whether err was created with UserNotFoundf() or
 // NewUserNotFound().
 func IsUserNotFound(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*userNotFound)
-	return ok
-}
-
-// unauthorized represents an error when an operation is unauthorized.
-type unauthorized struct {
-	Err
+	return Is(err, UserNotFound)
 }
 
 // Unauthorizedf returns an error which satisfies IsUnauthorized().
 func Unauthorizedf(format string, args ...interface{}) error {
-	return &unauthorized{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		Unauthorized,
+	}
 }
 
 // NewUnauthorized returns an error which wraps err and satisfies
 // IsUnauthorized().
 func NewUnauthorized(err error, msg string) error {
-	return &unauthorized{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		Unauthorized,
+	}
 }
 
 // IsUnauthorized reports whether err was created with Unauthorizedf() or
 // NewUnauthorized().
 func IsUnauthorized(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*unauthorized)
-	return ok
-}
-
-// notImplemented represents an error when something is not
-// implemented.
-type notImplemented struct {
-	Err
+	return Is(err, Unauthorized)
 }
 
 // NotImplementedf returns an error which satisfies IsNotImplemented().
 func NotImplementedf(format string, args ...interface{}) error {
-	return &notImplemented{wrap(nil, format, " not implemented", args...)}
+	return &errWithType{
+		wrap(nil, format, " not implemented", args...),
+		NotImplemented,
+	}
 }
 
 // NewNotImplemented returns an error which wraps err and satisfies
 // IsNotImplemented().
 func NewNotImplemented(err error, msg string) error {
-	return &notImplemented{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotImplemented,
+	}
 }
 
 // IsNotImplemented reports whether err was created with
 // NotImplementedf() or NewNotImplemented().
 func IsNotImplemented(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notImplemented)
-	return ok
-}
-
-// alreadyExists represents and error when something already exists.
-type alreadyExists struct {
-	Err
+	return Is(err, NotImplemented)
 }
 
 // AlreadyExistsf returns an error which satisfies IsAlreadyExists().
 func AlreadyExistsf(format string, args ...interface{}) error {
-	return &alreadyExists{wrap(nil, format, " already exists", args...)}
+	return &errWithType{
+		wrap(nil, format, " already exists", args...),
+		AlreadyExists,
+	}
 }
 
 // NewAlreadyExists returns an error which wraps err and satisfies
 // IsAlreadyExists().
 func NewAlreadyExists(err error, msg string) error {
-	return &alreadyExists{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		AlreadyExists,
+	}
 }
 
 // IsAlreadyExists reports whether the error was created with
 // AlreadyExistsf() or NewAlreadyExists().
 func IsAlreadyExists(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*alreadyExists)
-	return ok
-}
-
-// notSupported represents an error when something is not supported.
-type notSupported struct {
-	Err
+	return Is(err, AlreadyExists)
 }
 
 // NotSupportedf returns an error which satisfies IsNotSupported().
 func NotSupportedf(format string, args ...interface{}) error {
-	return &notSupported{wrap(nil, format, " not supported", args...)}
+	return &errWithType{
+		wrap(nil, format, " not supported", args...),
+		NotSupported,
+	}
 }
 
 // NewNotSupported returns an error which wraps err and satisfies
 // IsNotSupported().
 func NewNotSupported(err error, msg string) error {
-	return &notSupported{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotSupported,
+	}
 }
 
 // IsNotSupported reports whether the error was created with
 // NotSupportedf() or NewNotSupported().
 func IsNotSupported(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notSupported)
-	return ok
-}
-
-// notValid represents an error when something is not valid.
-type notValid struct {
-	Err
+	return Is(err, NotSupported)
 }
 
 // NotValidf returns an error which satisfies IsNotValid().
 func NotValidf(format string, args ...interface{}) error {
-	return &notValid{wrap(nil, format, " not valid", args...)}
+	return &errWithType{
+		wrap(nil, format, " not valid", args...),
+		NotValid,
+	}
 }
 
 // NewNotValid returns an error which wraps err and satisfies IsNotValid().
 func NewNotValid(err error, msg string) error {
-	return &notValid{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotValid,
+	}
 }
 
 // IsNotValid reports whether the error was created with NotValidf() or
 // NewNotValid().
 func IsNotValid(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notValid)
-	return ok
-}
-
-// notProvisioned represents an error when something is not yet provisioned.
-type notProvisioned struct {
-	Err
+	return Is(err, NotValid)
 }
 
 // NotProvisionedf returns an error which satisfies IsNotProvisioned().
 func NotProvisionedf(format string, args ...interface{}) error {
-	return &notProvisioned{wrap(nil, format, " not provisioned", args...)}
+	return &errWithType{
+		wrap(nil, format, " not provisioned", args...),
+		NotProvisioned,
+	}
 }
 
 // NewNotProvisioned returns an error which wraps err that satisfies
 // IsNotProvisioned().
 func NewNotProvisioned(err error, msg string) error {
-	return &notProvisioned{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotProvisioned,
+	}
 }
 
 // IsNotProvisioned reports whether err was created with NotProvisionedf() or
 // NewNotProvisioned().
 func IsNotProvisioned(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notProvisioned)
-	return ok
-}
-
-// notAssigned represents an error when something is not yet assigned to
-// something else.
-type notAssigned struct {
-	Err
+	return Is(err, NotProvisioned)
 }
 
 // NotAssignedf returns an error which satisfies IsNotAssigned().
 func NotAssignedf(format string, args ...interface{}) error {
-	return &notAssigned{wrap(nil, format, " not assigned", args...)}
+	return &errWithType{
+		wrap(nil, format, " not assigned", args...),
+		NotAssigned,
+	}
 }
 
 // NewNotAssigned returns an error which wraps err that satisfies
 // IsNotAssigned().
 func NewNotAssigned(err error, msg string) error {
-	return &notAssigned{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotAssigned,
+	}
 }
 
 // IsNotAssigned reports whether err was created with NotAssignedf() or
 // NewNotAssigned().
 func IsNotAssigned(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notAssigned)
-	return ok
-}
-
-// badRequest represents an error when a request has bad parameters.
-type badRequest struct {
-	Err
+	return Is(err, NotAssigned)
 }
 
 // BadRequestf returns an error which satisfies IsBadRequest().
 func BadRequestf(format string, args ...interface{}) error {
-	return &badRequest{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		BadRequest,
+	}
 }
 
 // NewBadRequest returns an error which wraps err that satisfies
 // IsBadRequest().
 func NewBadRequest(err error, msg string) error {
-	return &badRequest{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		BadRequest,
+	}
 }
 
 // IsBadRequest reports whether err was created with BadRequestf() or
 // NewBadRequest().
 func IsBadRequest(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*badRequest)
-	return ok
-}
-
-// methodNotAllowed represents an error when an HTTP request
-// is made with an inappropriate method.
-type methodNotAllowed struct {
-	Err
+	return Is(err, BadRequest)
 }
 
 // MethodNotAllowedf returns an error which satisfies IsMethodNotAllowed().
 func MethodNotAllowedf(format string, args ...interface{}) error {
-	return &methodNotAllowed{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		MethodNotAllowed,
+	}
 }
 
 // NewMethodNotAllowed returns an error which wraps err that satisfies
 // IsMethodNotAllowed().
 func NewMethodNotAllowed(err error, msg string) error {
-	return &methodNotAllowed{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		MethodNotAllowed,
+	}
 }
 
 // IsMethodNotAllowed reports whether err was created with MethodNotAllowedf() or
 // NewMethodNotAllowed().
 func IsMethodNotAllowed(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*methodNotAllowed)
-	return ok
-}
-
-// forbidden represents an error when a request cannot be completed because of
-// missing privileges
-type forbidden struct {
-	Err
+	return Is(err, MethodNotAllowed)
 }
 
 // Forbiddenf returns an error which satistifes IsForbidden()
 func Forbiddenf(format string, args ...interface{}) error {
-	return &forbidden{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		Forbidden,
+	}
 }
 
 // NewForbidden returns an error which wraps err that satisfies
 // IsForbidden().
 func NewForbidden(err error, msg string) error {
-	return &forbidden{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		Forbidden,
+	}
 }
 
 // IsForbidden reports whether err was created with Forbiddenf() or
 // NewForbidden().
 func IsForbidden(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*forbidden)
-	return ok
-}
-
-// quotaLimitExceeded is emitted when an action failed due to a quota limit check.
-type quotaLimitExceeded struct {
-	Err
+	return Is(err, Forbidden)
 }
 
 // QuotaLimitExceededf returns an error which satisfies IsQuotaLimitExceeded.
 func QuotaLimitExceededf(format string, args ...interface{}) error {
-	return &quotaLimitExceeded{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		QuotaLimitExceeded,
+	}
 }
 
 // NewQuotaLimitExceeded returns an error which wraps err and satisfies
 // IsQuotaLimitExceeded.
 func NewQuotaLimitExceeded(err error, msg string) error {
-	return &quotaLimitExceeded{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		QuotaLimitExceeded,
+	}
 }
 
 // IsQuotaLimitExceeded returns true if the given error represents a
 // QuotaLimitExceeded error.
 func IsQuotaLimitExceeded(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*quotaLimitExceeded)
-	return ok
-}
-
-// notYetAvailable is the error returned when a resource is not yet available
-// but it might be in the future.
-type notYetAvailable struct {
-	Err
-}
-
-// IsNotYetAvailable reports err was created with NotYetAvailableF or
-// NewNotYetAvailable.
-func IsNotYetAvailable(err error) bool {
-	err = Cause(err)
-	_, ok := err.(*notYetAvailable)
-	return ok
+	return Is(err, QuotaLimitExceeded)
 }
 
 // NotYetAvailablef returns an error which satisfies IsNotYetAvailable.
 func NotYetAvailablef(format string, args ...interface{}) error {
-	return &notYetAvailable{wrap(nil, format, "", args...)}
+	return &errWithType{
+		wrap(nil, format, "", args...),
+		NotYetAvailable,
+	}
 }
 
 // NewNotYetAvailable returns an error which wraps err and satisfies
 // IsNotYetAvailable.
 func NewNotYetAvailable(err error, msg string) error {
-	return &notYetAvailable{wrap(err, msg, "")}
+	return &errWithType{
+		wrap(err, msg, ""),
+		NotYetAvailable,
+	}
+}
+
+// IsNotYetAvailable reports err was created with NotYetAvailablef or
+// NewNotYetAvailable.
+func IsNotYetAvailable(err error) bool {
+	return Is(err, NotYetAvailable)
 }

--- a/errortypes.go
+++ b/errortypes.go
@@ -75,9 +75,8 @@ type errWithType struct {
 func (e *errWithType) Is(target error) bool {
 	if &e.errType == nil {
 		return false
-	} else {
-		return target == e.errType
 	}
+	return target == e.errType
 }
 
 // Unwrap an errWithType gives the underlying Err

--- a/errortypes_test.go
+++ b/errortypes_test.go
@@ -50,7 +50,7 @@ func (t *errorInfo) equal(t0 *errorInfo) bool {
 	if t0 == nil {
 		return false
 	}
-	return t.errType == t0.errType
+	return t == t0
 }
 
 type errorTest struct {
@@ -66,14 +66,14 @@ func deferredAnnotatef(err error, format string, args ...interface{}) error {
 
 func mustSatisfy(c *gc.C, err error, errInfo *errorInfo) {
 	if errInfo != nil {
-		msg := fmt.Sprintf("For err := %#v, Is(err, %s) should be true", err, errInfo.errName)
+		msg := fmt.Sprintf("Is(err, %s) should be TRUE when err := %#v", errInfo.errName, err)
 		c.Check(errors.Is(err, errInfo.errType), gc.Equals, true, gc.Commentf(msg))
 	}
 }
 
 func mustNotSatisfy(c *gc.C, err error, errInfo *errorInfo) {
 	if errInfo != nil {
-		msg := fmt.Sprintf("For err := %#v, Is(err, %s) should be true", err, errInfo.errName)
+		msg := fmt.Sprintf("Is(err, %s) should be FALSE when err := %#v", errInfo.errName, err)
 		c.Check(errors.Is(err, errInfo.errType), gc.Equals, false, gc.Commentf(msg))
 	}
 }

--- a/errortypes_test.go
+++ b/errortypes_test.go
@@ -6,18 +6,17 @@ package errors_test
 import (
 	stderrors "errors"
 	"fmt"
-	"reflect"
-	"runtime"
 
 	"github.com/juju/errors"
 	gc "gopkg.in/check.v1"
 )
 
-// errorInfo holds information about a single error type: a satisfier
-// function, wrapping and variable arguments constructors and message
+// errorInfo holds information about a single error type: its type
+// and name, wrapping and variable arguments constructors and message
 // suffix.
 type errorInfo struct {
-	satisfier       func(error) bool
+	errType         errors.ConstError
+	errName         string
 	argsConstructor func(string, ...interface{}) error
 	wrapConstructor func(error, string) error
 	suffix          string
@@ -26,38 +25,32 @@ type errorInfo struct {
 // allErrors holds information for all defined errors. When adding new
 // errors, add them here as well to include them in tests.
 var allErrors = []*errorInfo{
-	{errors.IsTimeout, errors.Timeoutf, errors.NewTimeout, " timeout"},
-	{errors.IsNotFound, errors.NotFoundf, errors.NewNotFound, " not found"},
-	{errors.IsUserNotFound, errors.UserNotFoundf, errors.NewUserNotFound, " user not found"},
-	{errors.IsUnauthorized, errors.Unauthorizedf, errors.NewUnauthorized, ""},
-	{errors.IsNotImplemented, errors.NotImplementedf, errors.NewNotImplemented, " not implemented"},
-	{errors.IsAlreadyExists, errors.AlreadyExistsf, errors.NewAlreadyExists, " already exists"},
-	{errors.IsNotSupported, errors.NotSupportedf, errors.NewNotSupported, " not supported"},
-	{errors.IsNotValid, errors.NotValidf, errors.NewNotValid, " not valid"},
-	{errors.IsNotProvisioned, errors.NotProvisionedf, errors.NewNotProvisioned, " not provisioned"},
-	{errors.IsNotAssigned, errors.NotAssignedf, errors.NewNotAssigned, " not assigned"},
-	{errors.IsMethodNotAllowed, errors.MethodNotAllowedf, errors.NewMethodNotAllowed, ""},
-	{errors.IsBadRequest, errors.BadRequestf, errors.NewBadRequest, ""},
-	{errors.IsForbidden, errors.Forbiddenf, errors.NewForbidden, ""},
-	{errors.IsQuotaLimitExceeded, errors.QuotaLimitExceededf, errors.NewQuotaLimitExceeded, ""},
-	{errors.IsNotYetAvailable, errors.NotYetAvailablef, errors.NewNotYetAvailable, ""},
+	{errors.Timeout, "Timeout", errors.Timeoutf, errors.NewTimeout, " timeout"},
+	{errors.NotFound, "NotFound", errors.NotFoundf, errors.NewNotFound, " not found"},
+	{errors.UserNotFound, "UserNotFound", errors.UserNotFoundf, errors.NewUserNotFound, " user not found"},
+	{errors.Unauthorized, "Unauthorized", errors.Unauthorizedf, errors.NewUnauthorized, ""},
+	{errors.NotImplemented, "NotImplemented", errors.NotImplementedf, errors.NewNotImplemented, " not implemented"},
+	{errors.AlreadyExists, "AlreadyExists", errors.AlreadyExistsf, errors.NewAlreadyExists, " already exists"},
+	{errors.NotSupported, "NotSupported", errors.NotSupportedf, errors.NewNotSupported, " not supported"},
+	{errors.NotValid, "NotValid", errors.NotValidf, errors.NewNotValid, " not valid"},
+	{errors.NotProvisioned, "NotProvisioned", errors.NotProvisionedf, errors.NewNotProvisioned, " not provisioned"},
+	{errors.NotAssigned, "NotAssigned", errors.NotAssignedf, errors.NewNotAssigned, " not assigned"},
+	{errors.MethodNotAllowed, "MethodNotAllowed", errors.MethodNotAllowedf, errors.NewMethodNotAllowed, ""},
+	{errors.BadRequest, "BadRequest", errors.BadRequestf, errors.NewBadRequest, ""},
+	{errors.Forbidden, "Forbidden", errors.Forbiddenf, errors.NewForbidden, ""},
+	{errors.QuotaLimitExceeded, "QuotaLimitExceeded", errors.QuotaLimitExceededf, errors.NewQuotaLimitExceeded, ""},
+	{errors.NotYetAvailable, "NotYetAvailable", errors.NotYetAvailablef, errors.NewNotYetAvailable, ""},
 }
 
 type errorTypeSuite struct{}
 
 var _ = gc.Suite(&errorTypeSuite{})
 
-func (t *errorInfo) satisfierName() string {
-	value := reflect.ValueOf(t.satisfier)
-	f := runtime.FuncForPC(value.Pointer())
-	return f.Name()
-}
-
 func (t *errorInfo) equal(t0 *errorInfo) bool {
 	if t0 == nil {
 		return false
 	}
-	return t.satisfierName() == t0.satisfierName()
+	return t.errType == t0.errType
 }
 
 type errorTest struct {
@@ -73,15 +66,15 @@ func deferredAnnotatef(err error, format string, args ...interface{}) error {
 
 func mustSatisfy(c *gc.C, err error, errInfo *errorInfo) {
 	if errInfo != nil {
-		msg := fmt.Sprintf("%#v must satisfy %v", err, errInfo.satisfierName())
-		c.Check(err, Satisfies, errInfo.satisfier, gc.Commentf(msg))
+		msg := fmt.Sprintf("For err := %#v, Is(err, %s) should be true", err, errInfo.errName)
+		c.Check(errors.Is(err, errInfo.errType), gc.Equals, true, gc.Commentf(msg))
 	}
 }
 
 func mustNotSatisfy(c *gc.C, err error, errInfo *errorInfo) {
 	if errInfo != nil {
-		msg := fmt.Sprintf("%#v must not satisfy %v", err, errInfo.satisfierName())
-		c.Check(err, gc.Not(Satisfies), errInfo.satisfier, gc.Commentf(msg))
+		msg := fmt.Sprintf("For err := %#v, Is(err, %s) should be true", err, errInfo.errName)
+		c.Check(errors.Is(err, errInfo.errType), gc.Equals, false, gc.Commentf(msg))
 	}
 }
 

--- a/functions.go
+++ b/functions.go
@@ -6,6 +6,7 @@ package errors
 import (
 	stderrors "errors"
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -31,6 +32,18 @@ func Errorf(format string, args ...interface{}) error {
 	err := &Err{message: fmt.Sprintf(format, args...)}
 	err.SetLocation(1)
 	return err
+}
+
+// getLocation records the package path-qualified function name of the error at
+// callDepth stack frames above the call.
+func getLocation(callDepth int) (string, int) {
+	rpc := make([]uintptr, 1)
+	n := runtime.Callers(callDepth+2, rpc[:])
+	if n < 1 {
+		return "", 0
+	}
+	frame, _ := runtime.CallersFrames(rpc).Next()
+	return frame.Function, frame.Line
 }
 
 // Trace adds the location of the Trace call to the stack.  The Cause of the
@@ -212,13 +225,9 @@ type wrapper interface {
 	Underlying() error
 }
 
-type locationer interface {
-	Location() (string, int)
-}
-
 var (
 	_ wrapper    = (*Err)(nil)
-	_ locationer = (*Err)(nil)
+	_ Locationer = (*Err)(nil)
 	_ causer     = (*Err)(nil)
 )
 
@@ -236,7 +245,7 @@ func Details(err error) string {
 	s = append(s, '[')
 	for {
 		s = append(s, '{')
-		if err, ok := err.(locationer); ok {
+		if err, ok := err.(Locationer); ok {
 			file, line := err.Location()
 			if file != "" {
 				s = append(s, fmt.Sprintf("%s:%d", file, line)...)
@@ -287,7 +296,7 @@ func errorStack(err error) []string {
 	var lines []string
 	for {
 		var buff []byte
-		if err, ok := err.(locationer); ok {
+		if err, ok := err.(Locationer); ok {
 			file, line := err.Location()
 			// Strip off the leading GOPATH/src path elements.
 			if file != "" {

--- a/functions_test.go
+++ b/functions_test.go
@@ -173,7 +173,7 @@ func (*functionSuite) TestCause(c *gc.C) {
 	err = errors.Annotate(err, "annotated")
 	c.Assert(errors.Cause(err), gc.Equals, fmtErr)
 
-	err = errors.Maskf(err, "maksed")
+	err = errors.Maskf(err, "masked")
 	c.Assert(errors.Cause(err), gc.Equals, err)
 
 	// Look for a file that we know isn't there.


### PR DESCRIPTION
Following #52, this library now supports `errors.Is`, `errors.As`, and `errors.Unwrap` from Go's standard errors library. This PR changes the `IsX` functions from `errortypes.go` to use `errors.Is` under the hood:
* We've defined a new error type `ConstError`, whose values are "sentinel errors" representing a certain error type.
* We've defined `errWithType`, which is an `Err` bundled with its error type `errType ConstError`. `errWithType` implements an `Is` method that compares its argument to `errType`. This ensures e.g. `Is(e, NotFound)` works as expected.
* All the individual structs for different error types, e.g. `timeout`, `notFound` have been replaced with `errWithType`.
* For `X ConstError`, `Xf` and `NewX` now return `e errWithType` where `e.errType` is `X`.
* `IsX` functions are now implemented by comparison to `X`.

This is structurally quite a big change, but the errors should behave exactly as before (all the tests in `errortypes_test.go` pass).