### PR TITLE
[JUJU-790] Add GitHub Action to run `go test`

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -1,5 +1,5 @@
 name: Run `go test`
-on: [push, pull-request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   run-go-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -1,0 +1,18 @@
+name: Run `go test`
+on: [push, pull-request, workflow_dispatch]
+jobs:
+  run-go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Get version from go.mod
+        uses: Eun/go-mod-details@v1
+        id: go-mod-details
+      - name: Install Golang
+        uses: actions/setup-go@v2
+        with:
+          # Gets go version from the previous step
+          go-version: ${{ steps.go-mod-details.outputs.go_version }}
+      - name: Run test suite
+        run: go test -v

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -6,13 +6,15 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-      - name: Get version from go.mod
-        uses: Eun/go-mod-details@v1
-        id: go-mod-details
+      - name: Find required go version
+        id: go-version
+        run: |
+          set -euxo pipefail
+          echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
       - name: Install Golang
         uses: actions/setup-go@v2
         with:
           # Gets go version from the previous step
-          go-version: ${{ steps.go-mod-details.outputs.go_version }}
+          go-version: ${{ steps.go-version.outputs.version }}
       - name: Run test suite
         run: go test -v


### PR DESCRIPTION
This PR introduces a GitHub Action which installs the version of Go specified in `go.mod`, then runs `go test`. This action will be run as CI on pushes and pull requests.

The action has been tested locally on my machine using nektos/act.