### PR TITLE
Fixes panics found in Juju for nil errors.

### DIFF
--- a/error.go
+++ b/error.go
@@ -53,11 +53,20 @@ type locationError struct {
 }
 
 // newLocationError constructs a new Locationer error from the supplied error
-// with the location set to callDepth in the stack.
+// with the location set to callDepth in the stack. If a nill error is provided
+// to this function then a new empty error is constructed.
 func newLocationError(err error, callDepth int) *locationError {
 	le := &locationError{error: err}
 	le.function, le.line = getLocation(callDepth + 1)
 	return le
+}
+
+// Error implementes the error interface.
+func (l *locationError) Error() string {
+	if l.error == nil {
+		return ""
+	}
+	return l.error.Error()
 }
 
 // *locationError implements Locationer.Location interface

--- a/errortypes.go
+++ b/errortypes.go
@@ -85,11 +85,11 @@ func (e *errWithType) Unwrap() error {
 }
 
 func wrapErrorWithMsg(err error, msg string) error {
-	if msg == "" {
-		return err
-	}
 	if err == nil {
 		return stderror.New(msg)
+	}
+	if msg == "" {
+		return err
 	}
 	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/errortypes_test.go
+++ b/errortypes_test.go
@@ -167,3 +167,13 @@ func (*errorTypeSuite) TestAllErrors(c *gc.C) {
 
 	runErrorTests(c, errorTests, true)
 }
+
+// TestThatYouAlwaysGetError is a regression test for checking that the wrap
+// constructor for our error types always returns a valid error object even if
+// don't feed the construct with an instantiated error or a non empty string.
+func (*errorTypeSuite) TestThatYouAlwaysGetError(c *gc.C) {
+	for _, errType := range allErrors {
+		err := errType.wrapConstructor(nil, "")
+		c.Assert(err.Error(), gc.Equals, "")
+	}
+}


### PR DESCRIPTION
When supplying a nil error to an error type wrapper in Juju you risk a
panic on the Locationer as it relies on the error being non nil for the
Error() func to work.

Fix here is just to make an empty error when the error provided is nil.

This fix will allow users to not shoot their foot off.